### PR TITLE
Various improvements

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,10 @@ int main(int argc, char *argv[]) {
   auto rc = libusb_init(&context);
   Q_ASSERT(rc >= 0);
 
+  QCoreApplication::setOrganizationName("TUNA");
+  QCoreApplication::setOrganizationDomain("tuna.tsinghua.edu.cn");
+  QCoreApplication::setApplicationName("QSerial");
+
   QApplication app(argc, argv);
 
   MainWindow mw;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -314,24 +314,10 @@ void MainWindow::onDataReceived(QByteArray data) {
     // never happens
     break;
   }
-  if (recvShowTimeCheckBox->isChecked()) {
-    text = QString("[%1] %2")
-               .arg(QDateTime::currentDateTime().toString(Qt::ISODate))
-               .arg(text);
-  }
   appendText(text, Qt::red);
 }
 
 void MainWindow::appendText(QString text, QColor color) {
-  auto cursor = textBrowser->textCursor();
-  cursor.movePosition(QTextCursor::End);
-  textBrowser->setTextCursor(cursor);
-  textBrowser->setTextColor(color);
-  textBrowser->insertPlainText(text);
-  textBrowser->verticalScrollBar()->setValue(
-  textBrowser->verticalScrollBar()->maximum());
-
-
   QString arr;
   const ushort *s = text.utf16();
   while (*s != 0) {
@@ -342,6 +328,20 @@ void MainWindow::appendText(QString text, QColor color) {
   fitTerminal();
   QString js = QString("term.write(String.fromCharCode(") + arr + QString("));");
   webEngineView->page()->runJavaScript(js);
+
+  if (recvShowTimeCheckBox->isChecked()) {
+    if (!textBrowser->toPlainText().endsWith('\n')) {
+      text = QString("\n") + text;
+    }
+    text.replace("\n", QString("\n[%1] ")
+               .arg(QDateTime::currentDateTime().toString(Qt::ISODate)));
+  }
+  auto cursor = textBrowser->textCursor();
+  cursor.movePosition(QTextCursor::End);
+  textBrowser->setTextCursor(cursor);
+  textBrowser->setTextColor(color);
+  textBrowser->insertPlainText(text);
+  textBrowser->verticalScrollBar()->setValue(textBrowser->verticalScrollBar()->maximum());
 }
 
 void MainWindow::onReset() {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -411,6 +411,9 @@ void MainWindow::onOpen() {
                                    .arg(stopBitsComboBox->currentText())
                                    .arg(flowControlComboBox->currentText()));
       refreshOpenStatus();
+
+      // set focus to corresponding widget upon connection
+      onTabPageChanged(tabWidget->currentIndex());
     } else {
       statusBar()->showMessage("Failed");
     }
@@ -472,6 +475,16 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event) {
 
 void MainWindow::fitTerminal() {
    webEngineView->page()->runJavaScript(QString("if (term) term.fit();"));
+}
+
+void MainWindow::onTabPageChanged(int index) {
+  if (index == tabWidget->indexOf(tab_term)) {
+    fitTerminal();
+    webEngineView->setFocus();
+    webEngineView->page()->runJavaScript(QString("if (term) term.focus();"));
+  } else if (index == tabWidget->indexOf(tab_text)) {
+    inputPlainTextEdit->setFocus();
+  }
 }
 
 void MainWindow::resizeEvent(QResizeEvent* event)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -66,9 +66,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   webEngineView->page()->setWebChannel(channel);
   channel->registerObject(QString("interface"), intf);
 
-  terminalShowing = false;
-  webEngineView->hide();
-
   statisticsLabel = new QLabel(this);
   statusBar()->addPermanentWidget(statisticsLabel);
   onReset(); // reset and show statistics
@@ -442,17 +439,6 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event) {
         }
     }
     return QMainWindow::eventFilter(object, event);
-}
-
-void MainWindow::onToggleTerminal() {
-  terminalShowing = !terminalShowing;
-  if (terminalShowing) {
-    webEngineView->show();
-    textBrowser->hide();
-  } else {
-    webEngineView->hide();
-    textBrowser->show();
-  }
 }
 
 void MainWindow::fitTerminal() {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -51,6 +51,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     connect(port, SIGNAL(breakChanged(bool)), this, SLOT(onBreakChanged(bool)));
   }
 
+  loadSettings();
+
   bytesRecv = 0;
   bytesSent = 0;
 
@@ -411,6 +413,7 @@ void MainWindow::onOpen() {
                                    .arg(stopBitsComboBox->currentText())
                                    .arg(flowControlComboBox->currentText()));
       refreshOpenStatus();
+      saveSettings();
 
       // set focus to corresponding widget upon connection
       onTabPageChanged(tabWidget->currentIndex());
@@ -478,6 +481,7 @@ void MainWindow::fitTerminal() {
 }
 
 void MainWindow::onTabPageChanged(int index) {
+  settings.setValue("tabPane", index);
   if (index == tabWidget->indexOf(tab_term)) {
     fitTerminal();
     webEngineView->setFocus();
@@ -492,4 +496,34 @@ void MainWindow::resizeEvent(QResizeEvent* event)
    QMainWindow::resizeEvent(event);
    // resize after the size change has propagated into the WebView
    QTimer::singleShot(100, this, &MainWindow::fitTerminal);
+}
+
+void MainWindow::saveSettings() {
+  settings.setValue("baud", baudRateComboBox->currentText().toInt());
+  settings.setValue("dataBits", (QSerialPort::DataBits)dataBitsComboBox->currentText().toInt());
+  settings.setValue("parity", parityComboBox->currentIndex());
+  settings.setValue("stopBits", stopBitsComboBox->currentIndex());
+  settings.setValue("flowControl", flowControlComboBox->currentIndex());
+  settings.setValue("deviceName", serialPortComboBox->currentText());
+}
+
+void MainWindow::loadSettings() {
+  int baud = settings.value("baud", 115200).toInt();
+  baudRateComboBox->setCurrentText(QString::number(baud));
+
+  int dataBits = settings.value("dataBits", 8).toInt();
+  dataBitsComboBox->setCurrentText(QString::number(dataBits));
+
+  parityComboBox->setCurrentIndex(settings.value("parity", 0).toInt());
+  stopBitsComboBox->setCurrentIndex(settings.value("stopBits", 0).toInt());
+  flowControlComboBox->setCurrentIndex(settings.value("flowControl", 0).toInt());
+
+  QString name = settings.value("deviceName").toString();
+  for (int i = 0; i < serialPortComboBox->count(); i++) {
+      if (serialPortComboBox->itemText(i) == name) {
+          serialPortComboBox->setCurrentIndex(i);
+      }
+  }
+
+  tabWidget->setCurrentIndex(settings.value("tabPane", 0).toInt());
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -292,7 +292,7 @@ void MainWindow::appendText(QString text, QColor color) {
     arr += ',';
     s++;
   }
-  webEngineView->page()->runJavaScript(QString("term.fit()"));
+  fitTerminal();
   QString js = QString("term.write(String.fromCharCode(") + arr + QString("));");
   webEngineView->page()->runJavaScript(js);
 }
@@ -413,5 +413,15 @@ void MainWindow::onToggleTerminal() {
     webEngineView->hide();
     textBrowser->show();
   }
-  webEngineView->page()->runJavaScript(QString("term.fit()"));
+}
+
+void MainWindow::fitTerminal() {
+   webEngineView->page()->runJavaScript(QString("term.fit()"));
+}
+
+void MainWindow::resizeEvent(QResizeEvent* event)
+{
+   QMainWindow::resizeEvent(event);
+   // resize after the size change has propagated into the WebView
+   QTimer::singleShot(100, this, &MainWindow::fitTerminal);
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -37,12 +37,14 @@ private:
   void appendText(QString text, QColor color);
   bool eventFilter(QObject *object, QEvent *event);
   void fitTerminal();
+  void refreshStatistics();
 
   quint64 bytesRecv;
   quint64 bytesSent;
   QList<QPair<quint64, qint64>> recvRecord;
   QList<QPair<quint64, qint64>> sentRecord;
   QTimer *timer;
+  QLabel *statisticsLabel;
   bool terminalShowing;
 };
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -31,13 +31,13 @@ private slots:
   void onDataReceived(QByteArray data);
   void onIdle();
   void onBreakChanged(bool set);
+  void refreshStatistics();
 
 private:
   QList<SerialPort *> ports;
   void appendText(QString text, QColor color);
   bool eventFilter(QObject *object, QEvent *event);
   void fitTerminal();
-  void refreshStatistics();
 
   quint64 bytesRecv;
   quint64 bytesSent;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -27,6 +27,7 @@ private slots:
   void onClose();
   void onToggleOpen();
   void onMutualTest();
+  void onTabPageChanged(int index);
 
   void onDataReceived(QByteArray data);
   void onIdle();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -29,6 +29,7 @@ private slots:
   void onToggleOpen();
   void onMutualTest();
   void onTabPageChanged(int index);
+  void refreshStatistics();
 
   void onDataReceived(QByteArray data);
   void onIdle();
@@ -39,7 +40,6 @@ private:
   void appendText(QString text, QColor color);
   bool eventFilter(QObject *object, QEvent *event);
   void fitTerminal();
-  void refreshStatistics();
   void refreshOpenStatus();
   void saveSettings();
   void loadSettings();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -6,12 +6,14 @@
 #include <QMainWindow>
 #include <QSerialPort>
 #include <QWidget>
+#include <QJsonArray>
 
 class MainWindow : public QMainWindow, private Ui::MainWindow {
   Q_OBJECT
 
 public:
   explicit MainWindow(QWidget *parent = nullptr);
+  void sendBytes(const QByteArray &data);
 
 protected:
    void resizeEvent(QResizeEvent *event);
@@ -42,6 +44,20 @@ private:
   QList<QPair<quint64, qint64>> sentRecord;
   QTimer *timer;
   bool terminalShowing;
+};
+
+class JsInterface : public QObject
+{
+  Q_OBJECT
+private:
+  MainWindow* parentWindow;
+
+public:
+  JsInterface(MainWindow *_parent) : QObject(_parent) {
+    parentWindow = _parent;
+  }
+
+  Q_INVOKABLE void sendBytes(const QJsonArray& data) const;
 };
 
 #endif

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -13,6 +13,9 @@ class MainWindow : public QMainWindow, private Ui::MainWindow {
 public:
   explicit MainWindow(QWidget *parent = nullptr);
 
+protected:
+   void resizeEvent(QResizeEvent *event);
+
 private slots:
   void onReset();
   void onSend();
@@ -31,6 +34,7 @@ private:
   QList<SerialPort *> ports;
   void appendText(QString text, QColor color);
   bool eventFilter(QObject *object, QEvent *event);
+  void fitTerminal();
 
   quint64 bytesRecv;
   quint64 bytesSent;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -26,7 +26,6 @@ private slots:
   void onOpen();
   void onClose();
   void onMutualTest();
-  void onToggleTerminal();
 
   void onDataReceived(QByteArray data);
   void onIdle();
@@ -45,7 +44,6 @@ private:
   QList<QPair<quint64, qint64>> sentRecord;
   QTimer *timer;
   QLabel *statisticsLabel;
-  bool terminalShowing;
 };
 
 class JsInterface : public QObject

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -7,6 +7,7 @@
 #include <QSerialPort>
 #include <QWidget>
 #include <QJsonArray>
+#include <QSettings>
 
 class MainWindow : public QMainWindow, private Ui::MainWindow {
   Q_OBJECT
@@ -40,6 +41,8 @@ private:
   void fitTerminal();
   void refreshStatistics();
   void refreshOpenStatus();
+  void saveSettings();
+  void loadSettings();
 
   quint64 bytesRecv;
   quint64 bytesSent;
@@ -49,6 +52,7 @@ private:
   QLabel *statisticsLabel;
   QIcon playIcon, stopIcon;
   bool isOpened;
+  QSettings settings;
 };
 
 class JsInterface : public QObject

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -25,18 +25,20 @@ private slots:
   void onClear();
   void onOpen();
   void onClose();
+  void onToggleOpen();
   void onMutualTest();
 
   void onDataReceived(QByteArray data);
   void onIdle();
   void onBreakChanged(bool set);
-  void refreshStatistics();
 
 private:
   QList<SerialPort *> ports;
   void appendText(QString text, QColor color);
   bool eventFilter(QObject *object, QEvent *event);
   void fitTerminal();
+  void refreshStatistics();
+  void refreshOpenStatus();
 
   quint64 bytesRecv;
   quint64 bytesSent;
@@ -44,6 +46,8 @@ private:
   QList<QPair<quint64, qint64>> sentRecord;
   QTimer *timer;
   QLabel *statisticsLabel;
+  QIcon playIcon, stopIcon;
+  bool isOpened;
 };
 
 class JsInterface : public QObject

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -7,14 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>846</width>
-    <height>771</height>
+    <height>870</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>QSerial</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QHBoxLayout" name="horizontalLayout_23" stretch="1,3">
+   <layout class="QHBoxLayout" name="horizontalLayout_23" stretch="0,3">
     <item>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
@@ -379,7 +379,7 @@
         <property name="flat">
          <bool>false</bool>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_5">
+        <layout class="QHBoxLayout" name="horizontalLayout_15">
          <item>
           <layout class="QVBoxLayout" name="verticalLayout" stretch="1,1">
            <item>
@@ -646,152 +646,47 @@
         </layout>
        </widget>
       </item>
+      <item>
+       <widget class="QFrame" name="frame">
+        <layout class="QHBoxLayout" name="horizontalLayout_16">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="resetButton">
+           <property name="text">
+            <string>Reset Statistics</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </item>
     <item>
      <layout class="QVBoxLayout" name="verticalLayout_4" stretch="3,1">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="4,4,1">
+       <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="4,4">
         <item>
          <widget class="QTextBrowser" name="textBrowser"/>
         </item>
         <item>
-         <widget class="QWebEngineView" name="webEngineView">
-          <property name="url">
+         <widget class="QWebEngineView" name="webEngineView" native="true">
+          <property name="url" stdset="0">
            <url>
             <string>about:blank</string>
            </url>
           </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox_4">
-          <property name="minimumSize">
-           <size>
-            <width>150</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="title">
-           <string>Statistics</string>
-          </property>
-          <widget class="QLabel" name="label_8">
-           <property name="geometry">
-            <rect>
-             <x>10</x>
-             <y>30</y>
-             <width>101</width>
-             <height>16</height>
-            </rect>
-           </property>
-           <property name="text">
-            <string>Bytes Sent:</string>
-           </property>
-          </widget>
-          <widget class="QLabel" name="bytesSentLabel">
-           <property name="geometry">
-            <rect>
-             <x>10</x>
-             <y>50</y>
-             <width>101</width>
-             <height>16</height>
-            </rect>
-           </property>
-           <property name="text">
-            <string>0</string>
-           </property>
-          </widget>
-          <widget class="QLabel" name="label_10">
-           <property name="geometry">
-            <rect>
-             <x>10</x>
-             <y>80</y>
-             <width>101</width>
-             <height>16</height>
-            </rect>
-           </property>
-           <property name="text">
-            <string>Bytes Recv:</string>
-           </property>
-          </widget>
-          <widget class="QLabel" name="bytesRecvLabel">
-           <property name="geometry">
-            <rect>
-             <x>10</x>
-             <y>100</y>
-             <width>101</width>
-             <height>16</height>
-            </rect>
-           </property>
-           <property name="text">
-            <string>0</string>
-           </property>
-          </widget>
-          <widget class="QLabel" name="label_12">
-           <property name="geometry">
-            <rect>
-             <x>10</x>
-             <y>130</y>
-             <width>101</width>
-             <height>16</height>
-            </rect>
-           </property>
-           <property name="text">
-            <string>Recv Speed:</string>
-           </property>
-          </widget>
-          <widget class="QLabel" name="recvSpeedLabel">
-           <property name="geometry">
-            <rect>
-             <x>10</x>
-             <y>150</y>
-             <width>59</width>
-             <height>16</height>
-            </rect>
-           </property>
-           <property name="text">
-            <string>0</string>
-           </property>
-          </widget>
-          <widget class="QLabel" name="label_14">
-           <property name="geometry">
-            <rect>
-             <x>10</x>
-             <y>180</y>
-             <width>81</width>
-             <height>16</height>
-            </rect>
-           </property>
-           <property name="text">
-            <string>Send Speed:</string>
-           </property>
-          </widget>
-          <widget class="QLabel" name="sentSpeedLabel">
-           <property name="geometry">
-            <rect>
-             <x>10</x>
-             <y>200</y>
-             <width>59</width>
-             <height>16</height>
-            </rect>
-           </property>
-           <property name="text">
-            <string>0</string>
-           </property>
-          </widget>
-          <widget class="QPushButton" name="resetButton">
-           <property name="geometry">
-            <rect>
-             <x>0</x>
-             <y>230</y>
-             <width>114</width>
-             <height>32</height>
-            </rect>
-           </property>
-           <property name="text">
-            <string>Reset</string>
-           </property>
-          </widget>
          </widget>
         </item>
        </layout>
@@ -833,7 +728,7 @@
      <x>0</x>
      <y>0</y>
      <width>846</width>
-     <height>22</height>
+     <height>37</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuSerial">
@@ -904,22 +799,6 @@
  </customwidgets>
  <resources/>
  <connections>
-  <connection>
-   <sender>resetButton</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>onReset()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>722</x>
-     <y>296</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>728</x>
-     <y>603</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>sendButton</sender>
    <signal>clicked()</signal>
@@ -1029,6 +908,22 @@
     <hint type="destinationlabel">
      <x>422</x>
      <y>385</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>resetButton</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>onReset()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>122</x>
+     <y>813</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>422</x>
+     <y>434</y>
     </hint>
    </hints>
   </connection>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -260,6 +260,30 @@
            </item>
           </widget>
          </item>
+         <item row="6" column="1">
+          <widget class="QPushButton" name="openCloseButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Open</string>
+           </property>
+           <property name="icon">
+            <iconset resource="resources.qrc">
+             <normaloff>:/resources/play.svg</normaloff>:/resources/play.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="label_12">
+           <property name="text">
+            <string>Action</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -641,20 +665,6 @@
    <addaction name="menuTools"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
-  <widget class="QToolBar" name="toolBar">
-   <property name="windowTitle">
-    <string>toolBar</string>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-   <addaction name="actionOpen"/>
-   <addaction name="actionClose"/>
-   <addaction name="actionMutual_Test"/>
-  </widget>
   <action name="actionOpen">
    <property name="text">
     <string>Open</string>
@@ -684,7 +694,9 @@
    <header location="global">QtWebEngineWidgets/QWebEngineView</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="resources.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>sendButton</sender>
@@ -693,8 +705,8 @@
    <slot>onSend()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>821</x>
-     <y>639</y>
+     <x>816</x>
+     <y>698</y>
     </hint>
     <hint type="destinationlabel">
      <x>668</x>
@@ -741,8 +753,8 @@
    <slot>onBreak()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>216</x>
-     <y>713</y>
+     <x>177</x>
+     <y>716</y>
     </hint>
     <hint type="destinationlabel">
      <x>159</x>
@@ -757,8 +769,8 @@
    <slot>onClear()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>176</x>
-     <y>500</y>
+     <x>153</x>
+     <y>483</y>
     </hint>
     <hint type="destinationlabel">
      <x>226</x>
@@ -789,12 +801,28 @@
    <slot>onReset()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>122</x>
-     <y>813</y>
+     <x>135</x>
+     <y>771</y>
     </hint>
     <hint type="destinationlabel">
      <x>422</x>
      <y>434</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>openCloseButton</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>onToggleOpen()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>184</x>
+     <y>313</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>422</x>
+     <y>405</y>
     </hint>
    </hints>
   </connection>
@@ -806,6 +834,7 @@
   <slot>onClose()</slot>
   <slot>onBreak()</slot>
   <slot>onClear()</slot>
+  <slot>onToggleOpen()</slot>
   <slot>onMutualTest()</slot>
  </slots>
 </ui>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>846</width>
-    <height>870</height>
+    <height>812</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,324 +18,247 @@
     <item>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <widget class="QGroupBox" name="groupBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>220</width>
-          <height>300</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>220</width>
-          <height>16777215</height>
-         </size>
-        </property>
+       <widget class="QGroupBox" name="groupBox_4">
         <property name="title">
          <string>Serial Port Settings</string>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_7">
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout">
-           <item>
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>Port:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QComboBox" name="serialPortComboBox"/>
-           </item>
-          </layout>
+        <layout class="QFormLayout" name="formLayout">
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::ExpandingFieldsGrow</enum>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Port</string>
+           </property>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QLabel" name="label_2">
-             <property name="text">
-              <string>Baud Rate:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_2">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QComboBox" name="baudRateComboBox">
-             <property name="editable">
-              <bool>true</bool>
-             </property>
-             <property name="currentIndex">
-              <number>7</number>
-             </property>
-             <item>
-              <property name="text">
-               <string>1200</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>2400</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>4800</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>9600</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>19200</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>38400</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>57600</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>115200</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>230400</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-          </layout>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="serialPortComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <item>
-            <widget class="QLabel" name="label_3">
-             <property name="text">
-              <string>Data Bits:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_3">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QComboBox" name="dataBitsComboBox">
-             <property name="currentIndex">
-              <number>3</number>
-             </property>
-             <item>
-              <property name="text">
-               <string>5</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>6</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>7</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>8</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-          </layout>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Baud Rate</string>
+           </property>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item row="1" column="1">
+          <widget class="QComboBox" name="baudRateComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="editable">
+            <bool>true</bool>
+           </property>
+           <property name="currentText">
+            <string>115200</string>
+           </property>
+           <property name="currentIndex">
+            <number>7</number>
+           </property>
            <item>
-            <widget class="QLabel" name="label_4">
-             <property name="text">
-              <string>Parity:</string>
-             </property>
-            </widget>
+            <property name="text">
+             <string>1200</string>
+            </property>
            </item>
            <item>
-            <spacer name="horizontalSpacer_4">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
+            <property name="text">
+             <string>2400</string>
+            </property>
            </item>
            <item>
-            <widget class="QComboBox" name="parityComboBox">
-             <item>
-              <property name="text">
-               <string>No</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Even</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Odd</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Space</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Mark</string>
-              </property>
-             </item>
-            </widget>
+            <property name="text">
+             <string>4800</string>
+            </property>
            </item>
-          </layout>
+           <item>
+            <property name="text">
+             <string>9600</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>19200</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>38400</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>57600</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>115200</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>230400</string>
+            </property>
+           </item>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_5">
-           <item>
-            <widget class="QLabel" name="label_5">
-             <property name="text">
-              <string>Stop Bits:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_5">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QComboBox" name="stopBitsComboBox">
-             <item>
-              <property name="text">
-               <string>1</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>2</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>1.5</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-          </layout>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Data Bits</string>
+           </property>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item row="2" column="1">
+          <widget class="QComboBox" name="dataBitsComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="currentIndex">
+            <number>3</number>
+           </property>
            <item>
-            <widget class="QLabel" name="label_6">
-             <property name="text">
-              <string>Flow Control:</string>
-             </property>
-            </widget>
+            <property name="text">
+             <string>5</string>
+            </property>
            </item>
            <item>
-            <spacer name="horizontalSpacer_6">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
+            <property name="text">
+             <string>6</string>
+            </property>
            </item>
            <item>
-            <widget class="QComboBox" name="flowControlComboBox">
-             <item>
-              <property name="text">
-               <string>No</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Hardware</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Software</string>
-              </property>
-             </item>
-            </widget>
+            <property name="text">
+             <string>7</string>
+            </property>
            </item>
-          </layout>
+           <item>
+            <property name="text">
+             <string>8</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Parity</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QComboBox" name="parityComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <item>
+            <property name="text">
+             <string>No</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Even</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Odd</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Space</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Mark</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Stop Bits</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QComboBox" name="stopBitsComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <item>
+            <property name="text">
+             <string>1</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>2</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>1.5</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Flow Control</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QComboBox" name="flowControlComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <item>
+            <property name="text">
+             <string>No</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Hardware</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Software</string>
+            </property>
+           </item>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -354,294 +277,228 @@
        </spacer>
       </item>
       <item>
-       <widget class="QGroupBox" name="groupBox_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>220</width>
-          <height>130</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>220</width>
-          <height>130</height>
-         </size>
-        </property>
+       <widget class="QGroupBox" name="groupBox">
         <property name="title">
-         <string>Recv Settings</string>
+         <string>Receiver Settings</string>
         </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_15">
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout" stretch="1,1">
+        <layout class="QFormLayout" name="formLayout_2">
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::ExpandingFieldsGrow</enum>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Encoding</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="recvShowAsComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_7">
-             <item>
-              <widget class="QLabel" name="label_7">
-               <property name="text">
-                <string>Show As:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_7">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QComboBox" name="recvShowAsComboBox">
-               <item>
-                <property name="text">
-                 <string>Text (UTF-8)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Text (Big5)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Text (GB18030)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Text (Shift-JIS)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Hex</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-            </layout>
+            <property name="text">
+             <string>Text (UTF-8)</string>
+            </property>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_13">
-             <item>
-              <widget class="QCheckBox" name="recvShowTimeCheckBox">
-               <property name="text">
-                <string>Show Time</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="pushButton">
-               <property name="text">
-                <string>Clear</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <property name="text">
+             <string>Text (Big5)</string>
+            </property>
            </item>
-          </layout>
+           <item>
+            <property name="text">
+             <string>Text (GB18030)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Text (Shift-JIS)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Hex</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>Options</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="recvShowTimeCheckBox">
+           <property name="text">
+            <string>Show Time</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QPushButton" name="pushButton">
+           <property name="text">
+            <string>Clear</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
       </item>
       <item>
-       <widget class="QGroupBox" name="groupBox_3">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>220</width>
-          <height>200</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>220</width>
-          <height>16777215</height>
-         </size>
-        </property>
+       <widget class="QGroupBox" name="groupBox_2">
         <property name="title">
-         <string>Send Settings</string>
+         <string>Transmitter Settings</string>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_6">
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_2">
+        <layout class="QFormLayout" name="formLayout_3">
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::ExpandingFieldsGrow</enum>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_9">
+           <property name="text">
+            <string>Encoding</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="sendParseAsComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_9">
-             <item>
-              <widget class="QLabel" name="label_9">
-               <property name="text">
-                <string>Parse As:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_9">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QComboBox" name="sendParseAsComboBox">
-               <item>
-                <property name="text">
-                 <string>Text (UTF-8)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Text (Big5)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Text (GB18030)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Text (Shift-JIS)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Hex (No CRLF)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Base64</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Percent Encoding</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-            </layout>
+            <property name="text">
+             <string>Text (UTF-8)</string>
+            </property>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_10">
-             <item>
-              <widget class="QLabel" name="label_11">
-               <property name="text">
-                <string>Line Ending:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_10">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QComboBox" name="lineEndingComboBox">
-               <item>
-                <property name="text">
-                 <string>LF (\n)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>CR LF (\r \n)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>CR (\r)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>None</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-            </layout>
+            <property name="text">
+             <string>Text (Big5)</string>
+            </property>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_14">
-             <item>
-              <widget class="QCheckBox" name="sendShowTimeCheckBox">
-               <property name="text">
-                <string>Show Time</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="echoCheckBox">
-               <property name="text">
-                <string>Echo</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <property name="text">
+             <string>Text (GB18030)</string>
+            </property>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_12">
-             <item>
-              <widget class="QLabel" name="label_13">
-               <property name="text">
-                <string>Duration:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="breakDurationLineEdit">
-               <property name="placeholderText">
-                <string>ms</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="breakPushButton">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="text">
-                <string>BREAK</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <property name="text">
+             <string>Text (Shift-JIS)</string>
+            </property>
            </item>
-          </layout>
+           <item>
+            <property name="text">
+             <string>Hex (No CRLF)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Base64</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Percent Encoding</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_11">
+           <property name="text">
+            <string>Line Ending</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QComboBox" name="lineEndingComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <item>
+            <property name="text">
+             <string>LF (\n)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>CR LF (\r \n)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>CR (\r)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>None</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_13">
+           <property name="text">
+            <string>Duration</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QLineEdit" name="breakDurationLineEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="placeholderText">
+            <string>ms</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QPushButton" name="breakPushButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>BREAK</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_10">
+           <property name="text">
+            <string>Options</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="sendShowTimeCheckBox">
+           <property name="text">
+            <string>Show Time</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QCheckBox" name="echoCheckBox">
+           <property name="text">
+            <string>Echo</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -682,7 +539,7 @@
        </sizepolicy>
       </property>
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="tab_text">
        <attribute name="title">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -826,6 +826,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>tabWidget</sender>
+   <signal>currentChanged(int)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>onTabPageChanged(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>558</x>
+     <y>407</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>422</x>
+     <y>405</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>onSend()</slot>
@@ -836,5 +852,6 @@
   <slot>onClear()</slot>
   <slot>onToggleOpen()</slot>
   <slot>onMutualTest()</slot>
+  <slot>onTabPageChanged(int)</slot>
  </slots>
 </ui>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -14,7 +14,7 @@
    <string>QSerial</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QHBoxLayout" name="horizontalLayout_23" stretch="0,3">
+   <layout class="QHBoxLayout" name="horizontalLayout_23" stretch="0,0">
     <item>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
@@ -674,12 +674,75 @@
      </layout>
     </item>
     <item>
-     <layout class="QVBoxLayout" name="verticalLayout_4" stretch="3,1">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="4,4">
+     <widget class="QTabWidget" name="tabWidget">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="currentIndex">
+       <number>1</number>
+      </property>
+      <widget class="QWidget" name="tab_text">
+       <attribute name="title">
+        <string>Text</string>
+       </attribute>
+       <layout class="QHBoxLayout" name="horizontalLayout_18">
         <item>
-         <widget class="QTextBrowser" name="textBrowser"/>
+         <layout class="QVBoxLayout" name="verticalLayout_4" stretch="3,1">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="4">
+            <item>
+             <widget class="QTextBrowser" name="textBrowser"/>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <item>
+             <widget class="QPlainTextEdit" name="inputPlainTextEdit">
+              <property name="plainText">
+               <string/>
+              </property>
+              <property name="placeholderText">
+               <string>Shift+Enter to send</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="sendButton">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>50</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Open and Send</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab_term">
+       <attribute name="title">
+        <string>Terminal</string>
+       </attribute>
+       <layout class="QHBoxLayout" name="horizontalLayout_17">
+        <property name="leftMargin">
+         <number>12</number>
+        </property>
+        <property name="rightMargin">
+         <number>12</number>
+        </property>
+        <property name="bottomMargin">
+         <number>12</number>
+        </property>
         <item>
          <widget class="QWebEngineView" name="webEngineView" native="true">
           <property name="url" stdset="0">
@@ -690,35 +753,8 @@
          </widget>
         </item>
        </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <widget class="QPlainTextEdit" name="inputPlainTextEdit">
-          <property name="plainText">
-           <string/>
-          </property>
-          <property name="placeholderText">
-           <string>Shift+Enter to send</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="sendButton">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Open and Send</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
+      </widget>
+     </widget>
     </item>
    </layout>
   </widget>
@@ -743,7 +779,6 @@
      <string>Tools</string>
     </property>
     <addaction name="actionMutual_Test"/>
-    <addaction name="actionEnable_Terminal"/>
    </widget>
    <addaction name="menuSerial"/>
    <addaction name="menuTools"/>
@@ -782,11 +817,6 @@
   <action name="actionMutual_Test">
    <property name="text">
     <string>Mutual Test</string>
-   </property>
-  </action>
-  <action name="actionEnable_Terminal">
-   <property name="text">
-    <string>Toggle Terminal</string>
    </property>
   </action>
  </widget>
@@ -896,22 +926,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>actionEnable_Terminal</sender>
-   <signal>triggered()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>onToggleTerminal()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>422</x>
-     <y>385</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>resetButton</sender>
    <signal>clicked()</signal>
    <receiver>MainWindow</receiver>
@@ -936,6 +950,5 @@
   <slot>onBreak()</slot>
   <slot>onClear()</slot>
   <slot>onMutualTest()</slot>
-  <slot>onToggleTerminal()</slot>
  </slots>
 </ui>

--- a/qserial.pro
+++ b/qserial.pro
@@ -1,5 +1,5 @@
 QT += core gui widgets serialport webenginewidgets
-equals(QT_VERSION, 6){
+equals(QT_MAJOR_VERSION, 6){
   QT += core5compat
 }
 CONFIG += console

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,9 +1,10 @@
-<!DOCTYPE RCC><RCC version="1.0">
-    <qresource>
+<RCC>
+    <qresource prefix="/">
         <file>resources/index.html</file>
         <file>resources/node_modules/xterm/dist/xterm.js</file>
         <file>resources/node_modules/xterm/dist/xterm.css</file>
         <file>resources/node_modules/xterm/dist/addons/fit/fit.js</file>
+        <file>resources/play.svg</file>
+        <file>resources/stop.svg</file>
     </qresource>
 </RCC>
-

--- a/resources/index.html
+++ b/resources/index.html
@@ -24,11 +24,47 @@
 </head>
 <body>
   <div id="terminal"></div>
+  <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
   <script>
     var term = new Terminal();
     Terminal.applyAddon(fit);
     term.open(document.getElementById('terminal'));
     term.fit();
+
+    function stringToUtf8ByteArray(str) {
+      var out = [], p = 0;
+      for (var i = 0; i < str.length; i++) {
+        var c = str.charCodeAt(i);
+        if (c < 128) {
+          out[p++] = c;
+        } else if (c < 2048) {
+          out[p++] = (c >> 6) | 192;
+          out[p++] = (c & 63) | 128;
+        } else if (
+            ((c & 0xFC00) == 0xD800) && (i + 1) < str.length &&
+            ((str.charCodeAt(i + 1) & 0xFC00) == 0xDC00)) {
+          // Surrogate Pair
+          c = 0x10000 + ((c & 0x03FF) << 10) + (str.charCodeAt(++i) & 0x03FF);
+          out[p++] = (c >> 18) | 240;
+          out[p++] = ((c >> 12) & 63) | 128;
+          out[p++] = ((c >> 6) & 63) | 128;
+          out[p++] = (c & 63) | 128;
+        } else {
+          out[p++] = (c >> 12) | 224;
+          out[p++] = ((c >> 6) & 63) | 128;
+          out[p++] = (c & 63) | 128;
+        }
+      }
+      return out;
+    };
+
+    new QWebChannel(qt.webChannelTransport, function (channel) {
+        var intf = channel.objects.interface;
+        term.on('data', function(str) {
+          var ch_array = stringToUtf8ByteArray(str);
+          intf.sendBytes(ch_array);
+        });
+    });
   </script>
 </body>
 </html>

--- a/resources/play.svg
+++ b/resources/play.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M8,5.14V19.14L19,12.14L8,5.14Z" /></svg>

--- a/resources/stop.svg
+++ b/resources/stop.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M18,18H6V6H18V18Z" /></svg>


### PR DESCRIPTION
* Fix Qt version detection
* Add input capability to xterm
* Relayout UI
  * Remove toolbar (mutual test can still be accessed from menu)
  * Move statistics to bottom right corner
  * Use tab pane to separate term and text mode
  * Change layout of left panel to form layout
* Save connection settings

<img width="1385" alt="截屏2021-12-24 下午5 54 21" src="https://user-images.githubusercontent.com/8972552/147342354-c5eae14e-615e-4403-83ff-dd57b75873a9.png">

<img width="1385" alt="截屏2021-12-24 下午5 54 32" src="https://user-images.githubusercontent.com/8972552/147342365-ae98e0b9-58a0-4b0c-9fa7-7ea8bc015ca3.png">

